### PR TITLE
Attempt a fix for service-worker registration

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
+/service-worker.js    /service-worker.js   200
 /*    /index.html   200


### PR DESCRIPTION
By specifying a redirect rule for service-worker, we can attempt to get a
proper MIME type for it and have it register without errors.